### PR TITLE
Add right-click starring for commands

### DIFF
--- a/CommandModels.cs
+++ b/CommandModels.cs
@@ -9,5 +9,11 @@ namespace overlayc
         public string description { get; set; } = null!;
         public List<string> @params { get; set; } = new();
         public Dictionary<string, List<string>> options { get; set; } = new();
+
+        // Indicates if this command is marked as a favorite by the user
+        public bool isStarred { get; set; }
+
+        // Label shown in the UI includes a star prefix when starred
+        public string displayLabel => (isStarred ? "★ " : "") + label;
     }
 }

--- a/CommandPanel.xaml
+++ b/CommandPanel.xaml
@@ -98,9 +98,10 @@
 
     <DataTemplate DataType="{x:Type local:Command}">
       <Button Style="{StaticResource CommandButtonStyle}"
-              Content="{Binding label}"
+              Content="{Binding displayLabel}"
               ToolTip="{Binding description}"
-              Click="OnCommandClick"/>
+              Click="OnCommandClick"
+              MouseRightButtonUp="OnCommandRightClick"/>
     </DataTemplate>
 
     <Style x:Key="InvisibleRepeatButton" TargetType="RepeatButton">

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -54,6 +54,7 @@ namespace overlayc
 
             settings = SettingsManager.Load(SettingsFileName)
                        ?? new SettingsData { HorizontalMode = true };
+            settings.Favorites ??= new();
             if (settings.WindowLeft.HasValue) Left = settings.WindowLeft.Value;
             if (settings.WindowTop .HasValue) Top  = settings.WindowTop.Value;
 
@@ -91,6 +92,7 @@ namespace overlayc
 
             commandsData = CommandLoader.LoadCommands(
                 Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "commands.json"));
+            ApplyFavoriteFlags();
             cmdPanel = new CommandPanel(commandsData);
 
             PreviewMouseLeftButtonDown += Window_PreviewMouseLeftButtonDown;
@@ -288,6 +290,23 @@ namespace overlayc
         private void CloseButton_Click(object sender, RoutedEventArgs e)
         {
             Application.Current.Shutdown();
+        }
+
+        private void ApplyFavoriteFlags()
+        {
+            foreach (var cat in commandsData.Values)
+                foreach (var grp in cat.Values)
+                    foreach (var cmd in grp)
+                        cmd.isStarred = settings.Favorites.Contains(cmd.template);
+        }
+
+        public void UpdateFavorite(Command cmd)
+        {
+            if (cmd.isStarred)
+                settings.Favorites.Add(cmd.template);
+            else
+                settings.Favorites.Remove(cmd.template);
+            SettingsManager.Save(SettingsFileName, settings);
         }
     }
 }

--- a/SettingsData.cs
+++ b/SettingsData.cs
@@ -8,5 +8,8 @@ namespace overlayc
         public double? WindowTop      { get; set; }
         public bool   HorizontalMode  { get; set; }
         public bool   InvertButtons   { get; set; }
+
+        // Templates of commands marked as favorites
+        public HashSet<string> Favorites { get; set; } = new();
     }
 }

--- a/SettingsWindow.xaml.cs
+++ b/SettingsWindow.xaml.cs
@@ -13,6 +13,7 @@ namespace overlayc
 
             settings = SettingsManager.Load("settings.json")
                        ?? new SettingsData { HorizontalMode = true };
+            settings.Favorites ??= new();
 
             HorizontalModeCheckbox.IsChecked = settings.HorizontalMode;
             InvertButtonsCheckbox.IsChecked  = settings.InvertButtons;


### PR DESCRIPTION
## Summary
- support favorites in settings
- show star prefix for favorite commands
- sort lists by favorites then alphabetically
- allow toggling star via right-click
