### PR TITLE
Implement command editor window

### DIFF
--- a/CommandEditorWindow.xaml
+++ b/CommandEditorWindow.xaml
@@ -1,0 +1,98 @@
+<Window x:Class="overlayc.CommandEditorWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Command Editor"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        Background="Transparent"
+        SizeToContent="WidthAndHeight"
+        ResizeMode="NoResize"
+        WindowStartupLocation="CenterScreen"
+        ShowInTaskbar="False"
+        FontFamily="Nocturne Serif"
+        FontSize="21"
+        Foreground="White">
+  <Window.Resources>
+    <SolidColorBrush x:Key="WindowBg"  Color="#181818"/>
+    <SolidColorBrush x:Key="BtnBg"     Color="#2A2A2A"/>
+    <SolidColorBrush x:Key="BtnBorder" Color="#555"/>
+
+    <Style x:Key="WindowCloseButtonStyle" TargetType="Button">
+      <Setter Property="Width" Value="24"/>
+      <Setter Property="Height" Value="24"/>
+      <Setter Property="Background" Value="Transparent"/>
+      <Setter Property="Foreground" Value="White"/>
+      <Setter Property="BorderBrush" Value="Transparent"/>
+      <Setter Property="BorderThickness" Value="0"/>
+      <Setter Property="Cursor" Value="Hand"/>
+      <Setter Property="Template">
+        <Setter.Value>
+          <ControlTemplate TargetType="Button">
+            <Border Background="{TemplateBinding Background}" CornerRadius="12">
+              <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            </Border>
+            <ControlTemplate.Triggers>
+              <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="#333"/>
+              </Trigger>
+              <Trigger Property="IsPressed" Value="True">
+                <Setter Property="Background" Value="#555"/>
+              </Trigger>
+            </ControlTemplate.Triggers>
+          </ControlTemplate>
+        </Setter.Value>
+      </Setter>
+    </Style>
+
+    <Style TargetType="Button" BasedOn="{StaticResource WindowCloseButtonStyle}">
+      <Setter Property="MinWidth" Value="120"/>
+      <Setter Property="Background" Value="{StaticResource BtnBg}"/>
+      <Setter Property="BorderBrush" Value="{StaticResource BtnBorder}"/>
+      <Setter Property="BorderThickness" Value="1"/>
+      <Setter Property="Padding" Value="12,6"/>
+      <Setter Property="Margin" Value="4"/>
+      <Setter Property="FontWeight" Value="SemiBold"/>
+      <Setter Property="HorizontalAlignment" Value="Center"/>
+    </Style>
+  </Window.Resources>
+
+  <Border Background="{StaticResource WindowBg}"
+          CornerRadius="6"
+          Padding="32,16,32,24"
+          MinWidth="600"
+          MouseLeftButtonDown="Border_MouseLeftButtonDown">
+    <Grid>
+      <Button x:Name="CloseX"
+              Style="{StaticResource WindowCloseButtonStyle}"
+              Content="✕"
+              HorizontalAlignment="Right"
+              VerticalAlignment="Top"
+              Click="CloseButton_Click"/>
+
+      <StackPanel HorizontalAlignment="Center"
+                  VerticalAlignment="Top"
+                  Margin="0,16,0,0"
+                  Width="500">
+        <TextBlock Text="Command Editor"
+                   FontSize="26"
+                   HorizontalAlignment="Center"
+                   Margin="0,0,0,16"/>
+
+        <ComboBox x:Name="PresetDropdown" Margin="0,0,0,12"/>
+        <TreeView x:Name="CommandTree" Height="300" Margin="0,0,0,12"/>
+        <StackPanel x:Name="CommandEditPanel" Visibility="Collapsed" Margin="0,0,0,12">
+          <TextBlock Text="Label:" FontSize="16"/>
+          <TextBox x:Name="CmdLabelBox" FontSize="16" Margin="0,0,0,4"/>
+          <TextBlock Text="Template:" FontSize="16"/>
+          <TextBox x:Name="CmdTemplateBox" FontSize="16"/>
+        </StackPanel>
+
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+          <Button x:Name="SaveButton"  Content="Save"/>
+          <Button x:Name="SaveAsButton" Content="Save As"/>
+          <Button x:Name="CloseButton" Content="Close"/>
+        </StackPanel>
+      </StackPanel>
+    </Grid>
+  </Border>
+</Window>

--- a/CommandEditorWindow.xaml.cs
+++ b/CommandEditorWindow.xaml.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using Newtonsoft.Json;
+
+namespace overlayc
+{
+    public partial class CommandEditorWindow : Window
+    {
+        private readonly string baseDir = AppDomain.CurrentDomain.BaseDirectory;
+        private Dictionary<string, Dictionary<string, List<Command>>> commandsData = new();
+        private string currentFile;
+        private Command? selectedCommand;
+
+        public event Action<string>? CommandsSaved;
+
+        public CommandEditorWindow(string presetFile)
+        {
+            InitializeComponent();
+            currentFile = presetFile;
+
+            PresetDropdown.SelectionChanged += PresetDropdown_SelectionChanged;
+            CommandTree.SelectedItemChanged += OnSelectedItemChanged;
+            CmdLabelBox.TextChanged += CmdLabelBox_TextChanged;
+            CmdTemplateBox.TextChanged += CmdTemplateBox_TextChanged;
+            SaveButton.Click += OnSave;
+            SaveAsButton.Click += OnSaveAs;
+            CloseButton.Click += (_,__) => Close();
+            CloseX.Click += (_,__) => Close();
+
+            LoadPresetList();
+            LoadPreset(Path.Combine(baseDir, presetFile));
+        }
+
+        private void LoadPresetList()
+        {
+            var files = Directory.GetFiles(baseDir, "commands*.json")
+                .Select(Path.GetFileName)
+                .OrderBy(f => f)
+                .ToList();
+            if (!files.Contains(currentFile))
+                files.Insert(0, currentFile);
+            PresetDropdown.ItemsSource = files;
+            PresetDropdown.SelectedItem = currentFile;
+        }
+
+        private void LoadPreset(string path)
+        {
+            commandsData = CommandLoader.LoadCommands(path);
+            BuildTree();
+        }
+
+        private void BuildTree()
+        {
+            CommandTree.Items.Clear();
+            foreach (var cat in commandsData)
+            {
+                var catItem = new TreeViewItem { Header = cat.Key };
+                foreach (var grp in cat.Value)
+                {
+                    var grpItem = new TreeViewItem { Header = grp.Key };
+                    foreach (var cmd in grp.Value)
+                    {
+                        var cmdItem = new TreeViewItem { Header = cmd.label, Tag = cmd };
+                        grpItem.Items.Add(cmdItem);
+                    }
+                    catItem.Items.Add(grpItem);
+                }
+                CommandTree.Items.Add(catItem);
+            }
+        }
+
+        private void PresetDropdown_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (PresetDropdown.SelectedItem is string file)
+            {
+                currentFile = file;
+                LoadPreset(Path.Combine(baseDir, file));
+            }
+        }
+
+        private void OnSelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
+        {
+            CommandEditPanel.Visibility = Visibility.Collapsed;
+            selectedCommand = null;
+            if (CommandTree.SelectedItem is TreeViewItem tv && tv.Tag is Command cmd)
+            {
+                selectedCommand = cmd;
+                CommandEditPanel.Visibility = Visibility.Visible;
+                CmdLabelBox.Text = cmd.label;
+                CmdTemplateBox.Text = cmd.template;
+            }
+        }
+
+        private void CmdLabelBox_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            if (selectedCommand != null)
+            {
+                selectedCommand.label = CmdLabelBox.Text;
+                if (CommandTree.SelectedItem is TreeViewItem tv)
+                    tv.Header = CmdLabelBox.Text;
+            }
+        }
+
+        private void CmdTemplateBox_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            if (selectedCommand != null)
+                selectedCommand.template = CmdTemplateBox.Text;
+        }
+
+        private void OnSave(object sender, RoutedEventArgs e)
+        {
+            SaveTo(Path.Combine(baseDir, currentFile));
+            CommandsSaved?.Invoke(currentFile);
+            Close();
+        }
+
+        private void OnSaveAs(object sender, RoutedEventArgs e)
+        {
+            var dlg = new Microsoft.Win32.SaveFileDialog
+            {
+                InitialDirectory = baseDir,
+                FileName = currentFile,
+                Filter = "JSON files|*.json"
+            };
+            if (dlg.ShowDialog() == true)
+            {
+                currentFile = Path.GetFileName(dlg.FileName);
+                SaveTo(dlg.FileName);
+                CommandsSaved?.Invoke(currentFile);
+                Close();
+            }
+        }
+
+        private void SaveTo(string path)
+        {
+            var json = JsonConvert.SerializeObject(commandsData, Formatting.Indented);
+            File.WriteAllText(path, json);
+        }
+
+        private void Border_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            DragMove();
+        }
+    }
+}

--- a/SettingsData.cs
+++ b/SettingsData.cs
@@ -9,6 +9,9 @@ namespace overlayc
         public bool   HorizontalMode  { get; set; }
         public bool   InvertButtons   { get; set; }
 
+        // Which commands preset file is active
+        public string? CommandPreset { get; set; }
+
         // Templates of commands marked as favorites
         public HashSet<string> Favorites { get; set; } = new();
     }

--- a/SettingsWindow.xaml.cs
+++ b/SettingsWindow.xaml.cs
@@ -24,7 +24,7 @@ namespace overlayc
             InvertButtonsCheckbox.Unchecked  += OnToggle;
 
             EditCommandsButton.Click         += (_,__) =>
-                MessageBox.Show("Command Editor coming soon");
+                (Owner as MainWindow)?.OpenEditCommands();
 
             CloseButton.Click                += (_,__) => Close();
             CloseX.Click                     += (_,__) => Close();


### PR DESCRIPTION
## Summary
- add new `CommandEditorWindow` for editing command presets
- support selecting presets and editing command label/template
- remember chosen preset in settings
- reload commands when preset saved
- wire settings button to open the editor
