### PR TITLE
Fix close button handler in CommandEditorWindow

### DIFF
--- a/CommandEditorWindow.xaml
+++ b/CommandEditorWindow.xaml
@@ -90,7 +90,7 @@
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
           <Button x:Name="SaveButton"  Content="Save"/>
           <Button x:Name="SaveAsButton" Content="Save As"/>
-          <Button x:Name="CloseButton" Content="Close"/>
+          <Button x:Name="CloseButton" Content="Close" Click="CloseButton_Click"/>
         </StackPanel>
       </StackPanel>
     </Grid>

--- a/CommandEditorWindow.xaml.cs
+++ b/CommandEditorWindow.xaml.cs
@@ -29,8 +29,6 @@ namespace overlayc
             CmdTemplateBox.TextChanged += CmdTemplateBox_TextChanged;
             SaveButton.Click += OnSave;
             SaveAsButton.Click += OnSaveAs;
-            CloseButton.Click += (_,__) => Close();
-            CloseX.Click += (_,__) => Close();
 
             LoadPresetList();
             LoadPreset(Path.Combine(baseDir, presetFile));
@@ -141,6 +139,8 @@ namespace overlayc
             var json = JsonConvert.SerializeObject(commandsData, Formatting.Indented);
             File.WriteAllText(path, json);
         }
+
+        private void CloseButton_Click(object sender, RoutedEventArgs e) => Close();
 
         private void Border_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
         {


### PR DESCRIPTION
## Summary
- add `CloseButton_Click` handler
- wire Close and ✕ buttons to the handler
