### PR TITLE
Add rename/delete with undo support

### DIFF
--- a/CommandEditorWindow.xaml
+++ b/CommandEditorWindow.xaml
@@ -88,6 +88,8 @@
         </StackPanel>
 
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+          <Button x:Name="UndoButton" Content="Undo"/>
+          <Button x:Name="RedoButton" Content="Redo"/>
           <Button x:Name="SaveButton"  Content="Save"/>
           <Button x:Name="SaveAsButton" Content="Save As"/>
           <Button x:Name="CloseButton" Content="Close" Click="CloseButton_Click"/>

--- a/CommandEditorWindow.xaml
+++ b/CommandEditorWindow.xaml
@@ -87,13 +87,19 @@
           <TextBox x:Name="CmdTemplateBox" FontSize="16"/>
         </StackPanel>
 
-        <WrapPanel HorizontalAlignment="Center">
-          <Button x:Name="UndoButton" Content="Undo"/>
-          <Button x:Name="RedoButton" Content="Redo"/>
-          <Button x:Name="SaveButton"  Content="Save"/>
-          <Button x:Name="SaveAsButton" Content="Save As"/>
-          <Button x:Name="CloseButton" Content="Close" Click="CloseButton_Click"/>
-        </WrapPanel>
+        <StackPanel HorizontalAlignment="Center">
+          <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+            <Button x:Name="UndoButton" Content="Undo"/>
+            <Button x:Name="RedoButton" Content="Redo"/>
+          </StackPanel>
+          <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+            <Button x:Name="SaveButton"  Content="Save"/>
+            <Button x:Name="SaveAsButton" Content="Save As"/>
+          </StackPanel>
+          <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+            <Button x:Name="CloseButton" Content="Close" Click="CloseButton_Click"/>
+          </StackPanel>
+        </StackPanel>
       </StackPanel>
     </Grid>
   </Border>

--- a/CommandEditorWindow.xaml
+++ b/CommandEditorWindow.xaml
@@ -87,13 +87,13 @@
           <TextBox x:Name="CmdTemplateBox" FontSize="16"/>
         </StackPanel>
 
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+        <WrapPanel HorizontalAlignment="Center">
           <Button x:Name="UndoButton" Content="Undo"/>
           <Button x:Name="RedoButton" Content="Redo"/>
           <Button x:Name="SaveButton"  Content="Save"/>
           <Button x:Name="SaveAsButton" Content="Save As"/>
           <Button x:Name="CloseButton" Content="Close" Click="CloseButton_Click"/>
-        </StackPanel>
+        </WrapPanel>
       </StackPanel>
     </Grid>
   </Border>

--- a/CommandEditorWindow.xaml.cs
+++ b/CommandEditorWindow.xaml.cs
@@ -20,6 +20,7 @@ namespace overlayc
         private bool isLoaded;
 
         public event Action<string>? CommandsSaved;
+        public event Action<string>? PresetChanged;
 
         public CommandEditorWindow(string presetFile)
         {
@@ -204,6 +205,7 @@ namespace overlayc
             {
                 currentFile = file;
                 LoadPreset(Path.Combine(baseDir, file));
+                PresetChanged?.Invoke(currentFile);
             }
         }
 
@@ -325,6 +327,7 @@ namespace overlayc
             {
                 currentFile = Path.GetFileName(dlg.FileName);
                 SaveTo(dlg.FileName);
+                LoadPresetList();
                 CommandsSaved?.Invoke(currentFile);
                 RebuildTree(true);
             }

--- a/CommandEditorWindow.xaml.cs
+++ b/CommandEditorWindow.xaml.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using Microsoft.VisualBasic;
 using Newtonsoft.Json;
 
 namespace overlayc

--- a/CommandEditorWindow.xaml.cs
+++ b/CommandEditorWindow.xaml.cs
@@ -102,7 +102,7 @@ namespace overlayc
             if (preserveState)
                 (expanded, selected) = CaptureState();
 
-            RebuildTree(true);
+            BuildTree();
 
             if (preserveState && expanded != null)
                 ApplyState(expanded, selected);

--- a/CommandLoader.cs
+++ b/CommandLoader.cs
@@ -10,14 +10,28 @@ namespace overlayc
 
         public static Dictionary<string, Dictionary<string, List<Command>>> LoadCommands(string path)
         {
-            using var stream = File.OpenRead(path);
-            using var sr     = new StreamReader(stream);
-            using var reader = new JsonTextReader(sr);
+            if (!File.Exists(path))
+                return new();
 
-            var data = _serializer
-                .Deserialize<Dictionary<string, Dictionary<string, List<Command>>>>(reader);
+            try
+            {
+                using var stream = File.OpenRead(path);
+                using var sr     = new StreamReader(stream);
+                using var reader = new JsonTextReader(sr);
 
-            return data ?? new();
+                var data = _serializer
+                    .Deserialize<Dictionary<string, Dictionary<string, List<Command>>>>(reader);
+
+                return data ?? new();
+            }
+            catch (IOException)
+            {
+                return new();
+            }
+            catch (JsonException)
+            {
+                return new();
+            }
         }
     }
 }

--- a/InputDialog.xaml
+++ b/InputDialog.xaml
@@ -1,0 +1,42 @@
+<Window x:Class="overlayc.InputDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Input"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        Background="Transparent"
+        SizeToContent="WidthAndHeight"
+        ResizeMode="NoResize"
+        WindowStartupLocation="CenterOwner"
+        ShowInTaskbar="False"
+        FontFamily="Nocturne Serif"
+        FontSize="21"
+        Foreground="White">
+  <Window.Resources>
+    <SolidColorBrush x:Key="WindowBg"  Color="#181818"/>
+    <SolidColorBrush x:Key="BtnBg"     Color="#2A2A2A"/>
+    <SolidColorBrush x:Key="BtnBorder" Color="#555"/>
+
+    <Style x:Key="DialogButton" TargetType="Button">
+      <Setter Property="MinWidth" Value="120"/>
+      <Setter Property="Background" Value="{StaticResource BtnBg}"/>
+      <Setter Property="BorderBrush" Value="{StaticResource BtnBorder}"/>
+      <Setter Property="BorderThickness" Value="1"/>
+      <Setter Property="Padding" Value="12,6"/>
+      <Setter Property="Margin" Value="4"/>
+      <Setter Property="FontWeight" Value="SemiBold"/>
+    </Style>
+  </Window.Resources>
+
+  <Border Background="{StaticResource WindowBg}" Padding="24" CornerRadius="6">
+    <StackPanel>
+      <TextBlock x:Name="PromptText" Margin="0,0,0,8"/>
+      <TextBox x:Name="InputBox" Margin="0,0,0,8" MinWidth="200"/>
+      <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+        <Button x:Name="OkButton" Content="OK" Style="{StaticResource DialogButton}" Click="OkButton_Click" IsDefault="True"/>
+        <Button Content="Cancel" Style="{StaticResource DialogButton}" IsCancel="True"/>
+      </StackPanel>
+    </StackPanel>
+  </Border>
+</Window>
+

--- a/InputDialog.xaml.cs
+++ b/InputDialog.xaml.cs
@@ -1,0 +1,24 @@
+using System.Windows;
+
+namespace overlayc
+{
+    public partial class InputDialog : Window
+    {
+        public string Input => InputBox.Text;
+
+        public InputDialog(string title, string prompt, string defaultValue = "")
+        {
+            InitializeComponent();
+            Title = title;
+            PromptText.Text = prompt;
+            InputBox.Text = defaultValue;
+            Loaded += (_,__) => InputBox.Focus();
+        }
+
+        private void OkButton_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = true;
+        }
+    }
+}
+

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -261,6 +261,10 @@ namespace overlayc
                     SettingsManager.Save(SettingsFileName, settings);
                     ReloadCommands(file);
                 };
+                editor.PresetChanged += file =>
+                {
+                    ReloadCommands(file);
+                };
                 editor.ShowDialog();
             }
             catch (Exception ex)

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -249,17 +249,25 @@ namespace overlayc
 
         public void OpenEditCommands()
         {
-            var editor = new CommandEditorWindow(settings.CommandPreset ?? "commands.json")
+            try
             {
-                Owner = this
-            };
-            editor.CommandsSaved += file =>
+                var editor = new CommandEditorWindow(settings.CommandPreset ?? "commands.json")
+                {
+                    Owner = this
+                };
+                editor.CommandsSaved += file =>
+                {
+                    settings.CommandPreset = file;
+                    SettingsManager.Save(SettingsFileName, settings);
+                    ReloadCommands(file);
+                };
+                editor.ShowDialog();
+            }
+            catch (Exception ex)
             {
-                settings.CommandPreset = file;
-                SettingsManager.Save(SettingsFileName, settings);
-                ReloadCommands(file);
-            };
-            editor.ShowDialog();
+                MessageBox.Show($"Failed to open Command Editor:\n{ex.Message}",
+                    "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+            }
         }
 
         private void ReloadCommands(string file)


### PR DESCRIPTION
## Summary
- enable renaming and deleting of categories or groups in the command editor
- add Undo/Redo buttons with simple history caching
- keep window open on Save and reload overlay
